### PR TITLE
Kms - entitiy및 dto를 수정, 컨텐츠 update 로직을 수정

### DIFF
--- a/src/main/java/com/grepp/moodlink/app/model/admin/book/AdminBookRepositoryCustom.java
+++ b/src/main/java/com/grepp/moodlink/app/model/admin/book/AdminBookRepositoryCustom.java
@@ -9,7 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AdminBookRepositoryCustom {
 
-    void updateBook(BookDto book);
-
     Page<Book> findPaged(Pageable pageable);
 }

--- a/src/main/java/com/grepp/moodlink/app/model/admin/book/AdminBookRepositoryImpl.java
+++ b/src/main/java/com/grepp/moodlink/app/model/admin/book/AdminBookRepositoryImpl.java
@@ -28,29 +28,6 @@ public class AdminBookRepositoryImpl implements AdminBookRepositoryCustom {
     private final QBook book = QBook.book;
 
     @Override
-    @Transactional
-    public void updateBook(BookDto book) {
-        Book entity = em.find(Book.class, book.getIsbn());
-
-        if (entity == null) {
-            log.warn("도서 없음: {}", book.getIsbn());
-        }
-
-        assert entity != null;
-        entity.setGenre(book.getGenre());
-        if (book.getImage() != null) {
-            entity.setImage(book.getImage());
-        }
-        entity.setPublisher(book.getPublisher());
-        entity.setPublishedDate(book.getPublishedDate());
-        if (!entity.getDescription().equals(book.getDescription())) {
-            entity.setDescription(book.getDescription());
-            // 변경된 설명에 대한 embedding 값을 넣기 위해 null 값 넣기
-            entity.setEmbedding(null);
-        }
-    }
-
-    @Override
     public Page<Book> findPaged(Pageable pageable) {
 
         List<Book> content = queryFactory

--- a/src/main/java/com/grepp/moodlink/app/model/admin/music/AdminMusicRepositoryCustom.java
+++ b/src/main/java/com/grepp/moodlink/app/model/admin/music/AdminMusicRepositoryCustom.java
@@ -10,6 +10,4 @@ import org.springframework.stereotype.Repository;
 public interface AdminMusicRepositoryCustom {
 
     Page<Music> findPaged(Pageable pageable);
-
-    void updateBook(MusicDto dto);
 }

--- a/src/main/java/com/grepp/moodlink/app/model/admin/music/AdminMusicRepositoryImpl.java
+++ b/src/main/java/com/grepp/moodlink/app/model/admin/music/AdminMusicRepositoryImpl.java
@@ -46,21 +46,4 @@ public class AdminMusicRepositoryImpl implements AdminMusicRepositoryCustom {
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
-    @Override
-    @Transactional
-    public void updateBook(MusicDto music) {
-        Music entity = em.find(Music.class, music.getId());
-
-        entity.setGenre(music.getGenre());
-        if (music.getThumbnail() != null) {
-            entity.setThumbnail(music.getThumbnail());
-        }
-        entity.setGenre(music.getGenre());
-        entity.setDescription(music.getDescription());
-        if (!entity.getLyrics().equals(music.getLyrics())) {
-            entity.setLyrics(music.getLyrics());
-            // 변경된 설명에 대한 embedding 값을 넣기 위해 null 값 넣기
-            entity.setEmbedding(null);
-        }
-    }
 }

--- a/src/main/java/com/grepp/moodlink/app/model/data/book/BookGenreRepository.java
+++ b/src/main/java/com/grepp/moodlink/app/model/data/book/BookGenreRepository.java
@@ -1,0 +1,11 @@
+package com.grepp.moodlink.app.model.data.book;
+
+import com.grepp.moodlink.app.model.data.book.entity.BookGenre;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookGenreRepository extends JpaRepository<BookGenre, Long> {
+
+    BookGenre findByName(String genre);
+}

--- a/src/main/java/com/grepp/moodlink/app/model/data/book/BookService.java
+++ b/src/main/java/com/grepp/moodlink/app/model/data/book/BookService.java
@@ -2,6 +2,8 @@ package com.grepp.moodlink.app.model.data.book;
 
 import com.grepp.moodlink.app.model.data.book.dto.BookDto;
 import com.grepp.moodlink.app.model.data.book.entity.Book;
+import com.grepp.moodlink.infra.error.exceptions.CommonException;
+import com.grepp.moodlink.infra.response.ResponseCode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -21,6 +23,7 @@ public class BookService {
 
     private final BookRepository bookRepository;
     private final ModelMapper mapper;
+    private final BookGenreRepository bookGenreRepository;
 
     public void saveMusic(List<BookDto> bookDtos) {
 
@@ -34,7 +37,8 @@ public class BookService {
             book.setPublisher(dto.getPublisher());
             book.setPublishedDate(dto.getPublishedDate());
             book.setDescription(dto.getDescription());
-            book.setGenre(dto.getGenre());
+            book.setGenre(bookGenreRepository.findById(Long.parseLong(dto.getGenre())).orElseThrow());
+            book.setLikeCount(0L);
 
             bookRepository.save(book);
         }

--- a/src/main/java/com/grepp/moodlink/app/model/data/book/dto/BookDto.java
+++ b/src/main/java/com/grepp/moodlink/app/model/data/book/dto/BookDto.java
@@ -41,7 +41,7 @@ public class BookDto implements ContentDto {
         dto.setPublisher(book.getPublisher());
         dto.setPublishedDate(book.getPublishedDate());
         dto.setDescription(book.getDescription());
-        dto.setGenre(book.getGenre());
+        dto.setGenre(book.getGenre().getName());
 
         return dto;
     }

--- a/src/main/java/com/grepp/moodlink/app/model/data/book/entity/Book.java
+++ b/src/main/java/com/grepp/moodlink/app/model/data/book/entity/Book.java
@@ -1,17 +1,22 @@
 package com.grepp.moodlink.app.model.data.book.entity;
 
+import com.grepp.moodlink.app.model.data.music.entity.MusicGenre;
 import com.grepp.moodlink.infra.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
+@Builder
 @Entity
 @Table(name = "book")
 @Data
@@ -36,7 +41,9 @@ public class Book extends BaseEntity {
     private String summary;
     @Column(columnDefinition = "BLOB")
     private byte[] embedding;
-    private String genre;
+    @ManyToOne
+    @JoinColumn(name = "genre")
+    private BookGenre genre;
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     private Long likeCount;
     // 정렬을 위해 일단 임시로...

--- a/src/main/java/com/grepp/moodlink/app/model/data/book/entity/BookGenre.java
+++ b/src/main/java/com/grepp/moodlink/app/model/data/book/entity/BookGenre.java
@@ -1,0 +1,24 @@
+package com.grepp.moodlink.app.model.data.book.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "book_genre")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookGenre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    String name;
+
+}

--- a/src/main/java/com/grepp/moodlink/app/model/data/music/MusicGenreRepository.java
+++ b/src/main/java/com/grepp/moodlink/app/model/data/music/MusicGenreRepository.java
@@ -1,0 +1,9 @@
+package com.grepp.moodlink.app.model.data.music;
+
+import com.grepp.moodlink.app.model.data.music.entity.MusicGenre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MusicGenreRepository extends JpaRepository<MusicGenre, Long> {
+
+    MusicGenre findByName(String name);
+}

--- a/src/main/java/com/grepp/moodlink/app/model/data/music/MusicService.java
+++ b/src/main/java/com/grepp/moodlink/app/model/data/music/MusicService.java
@@ -22,6 +22,7 @@ public class MusicService {
 
     private final MusicRepository musicRepository;
     private final ModelMapper mapper;
+    private final MusicGenreRepository musicGenreRepository;
 
     public void saveMusic(List<MusicDto> musicDtos) {
 
@@ -30,14 +31,14 @@ public class MusicService {
             long count = musicRepository.count();
             music.setId("S" + count);
             music.setTitle(dto.getTitle());
-            music.setGenre(dto.getGenre());
+            music.setGenre(musicGenreRepository.findById(Long.parseLong(dto.getGenre())).orElseThrow());
             music.setSinger(dto.getSinger());
             music.setDescription(dto.getDescription());
             music.setLyrics(dto.getLyrics());
             music.setReleaseDate(dto.getReleaseDate());
             music.setThumbnail(String.valueOf(dto.getThumbnail()));
             music.setCreatedAt(LocalDate.now());
-            music.setLikeCount(dto.getLikeCount());
+            music.setLikeCount(0L);
 
             musicRepository.save(music);
         }

--- a/src/main/java/com/grepp/moodlink/app/model/data/music/dto/MusicDto.java
+++ b/src/main/java/com/grepp/moodlink/app/model/data/music/dto/MusicDto.java
@@ -45,7 +45,7 @@ public class MusicDto implements ContentDto {
         MusicDto dto = new MusicDto();
         dto.setId(music.getId());
         dto.setTitle(music.getTitle());
-        dto.setGenre(music.getGenre());
+        dto.setGenre(music.getGenre().getName());
         dto.setSinger(music.getSinger());
         dto.setDescription(music.getDescription());
         dto.setReleaseDate(music.getReleaseDate());

--- a/src/main/java/com/grepp/moodlink/app/model/data/music/entity/Music.java
+++ b/src/main/java/com/grepp/moodlink/app/model/data/music/entity/Music.java
@@ -1,12 +1,18 @@
 package com.grepp.moodlink.app.model.data.music.entity;
 
 import com.grepp.moodlink.infra.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -17,12 +23,15 @@ import org.springframework.data.annotation.LastModifiedDate;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class Music extends BaseEntity {
 
     @Id
     private String id;
     private String title;
-    private String genre;
+    @ManyToOne
+    @JoinColumn(name = "genre")
+    private MusicGenre genre;
     private String singer;
     @Column(columnDefinition = "TEXT")
     private String description;

--- a/src/main/java/com/grepp/moodlink/app/model/data/music/entity/MusicGenre.java
+++ b/src/main/java/com/grepp/moodlink/app/model/data/music/entity/MusicGenre.java
@@ -1,0 +1,24 @@
+package com.grepp.moodlink.app.model.data.music.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "music_genre")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MusicGenre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    String name;
+
+}

--- a/src/main/java/com/grepp/moodlink/app/model/recomend/LikeService.java
+++ b/src/main/java/com/grepp/moodlink/app/model/recomend/LikeService.java
@@ -5,6 +5,7 @@ import com.grepp.moodlink.app.model.data.book.BookRepository;
 import com.grepp.moodlink.app.model.data.book.BookService;
 import com.grepp.moodlink.app.model.data.book.dto.BookDto;
 import com.grepp.moodlink.app.model.data.book.entity.Book;
+import com.grepp.moodlink.app.model.data.book.entity.BookGenre;
 import com.grepp.moodlink.app.model.data.movie.MovieRepository;
 import com.grepp.moodlink.app.model.data.movie.MovieService;
 import com.grepp.moodlink.app.model.data.movie.dto.MovieInfoDto;
@@ -14,6 +15,7 @@ import com.grepp.moodlink.app.model.data.music.MusicRepository;
 import com.grepp.moodlink.app.model.data.music.MusicService;
 import com.grepp.moodlink.app.model.data.music.dto.MusicDto;
 import com.grepp.moodlink.app.model.data.music.entity.Music;
+import com.grepp.moodlink.app.model.data.music.entity.MusicGenre;
 import com.grepp.moodlink.app.model.recomend.entity.LikeDetailBooks;
 import com.grepp.moodlink.app.model.recomend.entity.LikeDetailMovies;
 import com.grepp.moodlink.app.model.recomend.entity.LikeDetailMusic;
@@ -258,10 +260,10 @@ public class LikeService {
         Map<String, Long> genreCount = new HashMap<>();
 
         for (Music music : musics) {
-            String genre = music.getGenre();
+            MusicGenre genre = music.getGenre();
             Long likeCount = music.getLikeCount();
-            if (genre != null && !genre.isBlank() && likeCount != null) {
-                genreCount.put(genre, genreCount.getOrDefault(genre, 0L) + likeCount);
+            if (genre != null && likeCount != null) {
+                genreCount.put(genre.getName(), genreCount.getOrDefault(genre.getName(), 0L) + likeCount);
             }
         }
 
@@ -300,10 +302,10 @@ public class LikeService {
         Map<String, Long> genreCount = new HashMap<>();
 
         for (Book book : books) {
-            String genre = book.getGenre();
+            BookGenre genre = book.getGenre();
             Long likeCount = book.getLikeCount();
-            if (genre != null && !genre.isBlank() && likeCount != null) {
-                genreCount.put(genre, genreCount.getOrDefault(genre, 0L) + likeCount);
+            if (genre != null && likeCount != null) {
+                genreCount.put(genre.getName(), genreCount.getOrDefault(genre.getName(), 0L) + likeCount);
             }
         }
 


### PR DESCRIPTION
📌 과제 설명

장르 테이블을 추가하여 entitiy및 dto를 수정하였습니다.
또한 컨텐츠 update 로직을 수정하였습니다.

👩‍💻 요구 사항과 구현 내용

관리자 페이지에서 장르 추가 삭제를 위해 책과 음악 쪽에도 장르 테이블을 추가하였습니다.
이에 따라서 entity에서 genre가 각각 BookGenre, MusicGenre로 변경되었습니다.

![image](https://github.com/user-attachments/assets/b80fdb3d-f273-4185-a8c9-a96460fbb4d0)
![image](https://github.com/user-attachments/assets/a4c7604c-68bd-46d0-86d1-ec3cb83e8acf)


***
dto를 수정할까 고민을 하다가 일단 String 값으로 냅두었기에 book과 bookDto, music과 musicDto를 자동으로 형변환 시켜주는 mapper 사용이 불가능합니다. 이 점 참고 부탁드립니다.
엔티티 컬럼의 속성이 변화하여서 기존 DB 사용 시 무조건 오류 발생합니다.
***
[genretable수정.zip](https://github.com/user-attachments/files/20583303/genretable.zip)


추가로 update문 로직을 수정하였습니당

✅ PR 포인트 & 궁금한 점

추천이 받아와지지 않아서 제가 가지고 있는 데이터에 이상이 있는지 한 번 확인 부탁드립니다.
